### PR TITLE
rt#86819 Add access to openssl's pending attribute on the ssl connection object

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -281,6 +281,10 @@ SSL_free(ssl)
         SSL* ssl
 
 int
+SSL_pending(ssl)
+        SSL* ssl
+
+int
 SSL_set_fd(ssl,fd)
         SSL* ssl
         int  fd

--- a/lib/Net/SSL.pm
+++ b/lib/Net/SSL.pm
@@ -198,6 +198,12 @@ sub get_cipher {
     *$self->{ssl_ssl}->get_cipher(@_);
 }
 
+sub pending {
+    my $self = shift;
+    $self = $REAL{$self} || $self;
+    *$self->{ssl_ssl}->pending(@_);
+}
+
 sub ssl_context {
     my $self = shift;
     $self = $REAL{$self} || $self;


### PR DESCRIPTION
This patch is required as part of a fix for rt#86812
