### PR TITLE
Makefile.PL:  More carefully and precisely load from inc/

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,9 +8,14 @@ use ExtUtils::MakeMaker;
 use File::Spec::Functions qw( catfile rel2abs );
 use Getopt::Long qw( GetOptionsFromArray );
 
-push @INC, '.';
-unless( require( catfile qw(inc IO Interactive Tiny.pm) ) ) {
-    die 'Your distribution is incomplete: Failed to load bundled IO::Interactive::Tiny';
+BEGIN {
+  # Must use a bundled version
+  # "./" prefix required to subvert @INC traversal
+  # "catfile" not useful here as it eats "." and may produces wrong \
+  #  under windows ( require always takes / )
+  local $@;
+  eval { require "./inc/IO/Interactive/Tiny.pm" } or
+    die "Your distribution is incomplete: Failed to load bundled IO::Interactive::Tiny\n$@";
 }
 
 run(\@ARGV, [qw{ssl crypto ssl32 ssleay32 eay32 libeay32 z}]);


### PR DESCRIPTION
This more carefully loads the dependency from `inc` without
necessitating re-polluting `@INC` globally.

This also negates various bugs in the existing implementation,
for instance, the fact that `require` auto-fatalizes, and the fact
that in order to avoid `@INC` traversal in conjunction with `require`,
you need to specify a path prefixed with either `./` or `/`.

`catfile` is useless here, as things like:

```
catfile(qw(. foo bar baz ))
```

Will helpfully eat the "."

Additionally, `require` by convention takes paths in Unix form, and
using windows paths to require should be considered a bug.