### PR TITLE
Use ExtUtils::PkgConfig to discover OpenSSL if available

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -277,6 +277,17 @@ sub filter_libs {
     my $opt = shift;
     my $libs = shift;
 
+    if (eval { require ExtUtils::PkgConfig } &&
+            ExtUtils::PkgConfig->exists('openssl')) {
+        my @libs = map { s/^-l//; $_ }
+            split(' ', ExtUtils::PkgConfig->libs_only_l('openssl'));
+        $opt->{libpath} = ExtUtils::PkgConfig->libs_only_L('openssl') // '';
+        $opt->{libpath} =~ s/^-L//;
+        $opt->{incpath} = ExtUtils::PkgConfig->cflags_only_I('openssl') // '';
+        $opt->{incpath} =~ s/-I//;
+        return \@libs;
+    }
+
     return $libs unless eval {
         require Devel::CheckLib;
         1;


### PR DESCRIPTION
Makefile.PL used to link to zlib regardless OpenSSL libraries needed
that or not. Just based on the presente of zlib on the system.

If OpenSSL required zlib but it was not installed, Crypt-SSLeay tests
failed because of underlinking. If OpenSSL did not require zlib, but
it was installed, Crypt/SSLeay.so pulled in useless zlib because of
overlinking. Overlinking polutes a process address space, enlarges an
attack surface and slows down execution.

This patch modifies Makefile.PL to optionally use ExtUtils::PkgConfig
to discover OpenSSL and its compiler and linker flags.